### PR TITLE
Correct rpc response structure

### DIFF
--- a/pili/rpc.go
+++ b/pili/rpc.go
@@ -91,8 +91,8 @@ func (r RPC) DelCall(ret interface{}, url string) (err error) {
 }
 
 type ErrorInfo struct {
-	Message string           `json:"message"`
-	ErrCode int              `json:"error"`
+	Message string           `json:"error"`
+	ErrCode int              `json:"errno"`
 	Details map[string]error `json:"details,omitempty"`
 	Code    int              `json:"code"`
 }


### PR DESCRIPTION
This pull request fixes response body unmarshalling problem. The existing Error structure seems to be wrong.

An example response body: {"error":"duplicated content","errno":400007}
The existing ErrorInfo struct won't decode.
